### PR TITLE
Delete word color from mainTheme

### DIFF
--- a/src/styles/mainTheme.tsx
+++ b/src/styles/mainTheme.tsx
@@ -3,17 +3,17 @@ import { DefaultTheme } from "styled-components";
 const mainTheme: DefaultTheme = {
   colors: {
     brands: {
-      baseColor: "##2daae1",
+      base: "#2daae1",
     },
     neutrals: {
-      darkColor: "#212529",
-      lightColor: "#fff",
-      baseColor: "##91a3b5",
+      dark: "#212529",
+      light: "#fff",
+      base: "#91a3b5",
     },
     feedback: {
-      successColor: "#2e0b2",
-      warningColor: "#e0d716",
-      alertColor: "#e0435d",
+      success: "#2e0b2",
+      warning: "#e0d716",
+      alert: "#e0435d",
     },
   },
   paddings: {

--- a/src/styles/styled.d.ts
+++ b/src/styles/styled.d.ts
@@ -4,17 +4,17 @@ declare module "styled-components" {
   export interface DefaultTheme {
     colors: {
       brands: {
-        baseColor: string;
+        base: string;
       };
       neutrals: {
-        darkColor: string;
-        lightColor: string;
-        baseColor: string;
+        dark: string;
+        light: string;
+        base: string;
       };
       feedback: {
-        successColor: string;
-        warningColor: string;
-        alertColor: string;
+        success: string;
+        warning: string;
+        alert: string;
       };
     };
     paddings: {


### PR DESCRIPTION
Correct mainTheme colors naming without  unnecessary # and delete color from naming of the colors.