### PR TITLE
Hide all files from search bots

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,3 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
-Disallow:
+Disallow: /


### PR DESCRIPTION
Todos los frontales deben estar ocultos a los robots de búsqueda.