### PR TITLE
Add post-merge hook to install dependencies if they have changed

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+if git diff HEAD~ HEAD --name-only | grep -E '^(package-lock\.json|yarn\.lock)$'; then
+  echo "Detected changes in dependencies, executing npm install..."
+  npm install
+fi
+


### PR DESCRIPTION
He creado un hook post-merge (se ejecutará después de cada pull) que detecta si hay cambiado el archivo `package-lock.json`, y en caso afirmativo lanza `npm install`.