### PR TITLE
Feature/cod 109 refactor login form validation

### DIFF
--- a/src/components/LoginForm/LoginForm.test.tsx
+++ b/src/components/LoginForm/LoginForm.test.tsx
@@ -105,8 +105,9 @@ describe("Given a LoginForm", () => {
     });
   });
 
-  describe("When it's rendered and the user clicks on the password text field and not typing on it, and then clicks on the email text field", () => {
+  describe("When it's rendered and the user clicks on the password text field and not typing on it, and then clicks on the email text field and types 'admin@admin.com'", () => {
     test("Then it should show a message with text 'Password is required'", async () => {
+      const userEmail = "admin@admin.com";
       const requiredPasswordMessage = "Password is required";
 
       customRender(<LoginForm />);
@@ -116,6 +117,7 @@ describe("Given a LoginForm", () => {
 
       const emailInput = screen.getByLabelText(emailLabel);
       await act(async () => await userEvent.click(emailInput));
+      await act(async () => await userEvent.type(emailInput, userEmail));
 
       const validationMessage = screen.getByText(requiredPasswordMessage);
 

--- a/src/components/LoginForm/LoginForm.tsx
+++ b/src/components/LoginForm/LoginForm.tsx
@@ -44,7 +44,7 @@ const LoginForm = (): JSX.Element => {
           onBlur={formik.handleBlur}
         ></input>
         <span className="form-group__message">
-          {formik.touched.email && formik.errors.email}
+          {formik.dirty && formik.touched.email && formik.errors.email}
         </span>
       </div>
       <div className="form-group">
@@ -61,7 +61,7 @@ const LoginForm = (): JSX.Element => {
           onBlur={formik.handleBlur}
         ></input>
         <span className="form-group__message">
-          {formik.touched.password && formik.errors.password}
+          {formik.dirty && formik.touched.password && formik.errors.password}
         </span>
       </div>
       {feedback && (


### PR DESCRIPTION
Se ha refactorizado el formulario de login para que los mensajes de validación de los controles de cormulario aparezcan cuando el usuario ha escrito algo y no solo cuando ha hecho click sobre ellos.

Se ha añadido la propiedad `formik.dirty` además de la propiedad `formik.touch` que ya tenían los controles de formulario. Ahora el mensaje aparece si el usuario escribe y luego hace click en otro control de formulario.

Seguramente se puede mejorar pero tras muchas pruebas esta me ha parecido la mejor opción de cara a la experiencia de usuario. @coders-app/devs alguna sugerencia para mejorarlo?