### PR TITLE
Add with credentials true to request of verifyUser

### DIFF
--- a/src/hooks/useUser/useUser.ts
+++ b/src/hooks/useUser/useUser.ts
@@ -43,7 +43,8 @@ const useUser = (): UseUserStructure => {
   const verifyUser = useCallback(async () => {
     try {
       const userData = await axios.get<VerifyUserResponse>(
-        `${apiPaths.root}${apiPaths.users.verify}`
+        `${apiPaths.root}${apiPaths.users.verify}`,
+        { withCredentials: true }
       );
 
       dispatch(loadUserDataActionCreator(userData.data.userPayload));


### PR DESCRIPTION
La función de verifyUser del customHook de useUser necesita añadirle a la petición de axios al endpoint de verify-token withCredentials true. Sin añadir está línea de código la cookie llegaba vacía al back porque no se podía acceder al contenido de la cookie. 